### PR TITLE
Make options translatable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build
+**/l10n.js

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "extlib/webextensions-lib-l10n"]
+	path = extlib/webextensions-lib-l10n
+	url = https://github.com/piroor/webextensions-lib-l10n.git

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
-.PHONY: setup build
+.PHONY: prepare build
 
 all: build
 
-build: setup
+build: prepare
 	web-ext build --overwrite-dest
 
-setup: extlib/webextensions-lib-l10n/l10n.js
+prepare: extlib/webextensions-lib-l10n/l10n.js
 	git submodule update
 	cp extlib/webextensions-lib-l10n/l10n.js ./
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+.PHONY: setup build
+
+all: build
+
+build: setup
+	web-ext build --overwrite-dest
+
+setup: extlib/webextensions-lib-l10n/l10n.js
+	git submodule update
+	cp extlib/webextensions-lib-l10n/l10n.js ./
+
+extlib/webextensions-lib-l10n/l10n.js:
+	git submodule update --init
+

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Download the code from Github
 ```sh
 git clone https://github.com/itseco/to-google-translate.git
 cd to-google-translate
+make prepare
 ```
 
 Run in the root folder extension the command

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -33,5 +33,56 @@
                 "example": "en"
             }
         }
+    },
+
+
+    "optionsPageTitle": {
+        "message": "To Google Translate - Options page",
+        "description": "Title of the options page itself."
+    },
+
+    "optionsTitle": {
+        "message": "Settings",
+        "description": "Visible title in the options page."
+    },
+
+    "optionsNoteForEncounteringMultipleLanguage": {
+        "message": "Set the From field to 'auto' to use when encountering multiple languages.",
+        "description": "Notice message for language settings"
+    },
+    "optionsTTCaption": {
+        "message": "Translate Text",
+        "description": "Caption for text translation"
+    },
+    "optionsPageLang": {
+        "message": "From",
+        "description": "Preceding label for the page language"
+    },
+    "optionsUserLang": {
+        "message": "To",
+        "description": "Preceding label for the translated language"
+    },
+    "optionsEnableTT": {
+        "message": "Enable",
+        "description": "Label for the checkbox to show \"Translate\" menu item"
+    },
+
+    "optionsTTSCaption": {
+        "message": "Text To Speech",
+        "description": "Caption for text to speech"
+    },
+    "optionsEnableTTS": {
+        "message": "Enable",
+        "description": "Label for the checkbox to show \"Listen\" menu item"
+    },
+
+    "optionsSubmit": {
+        "message": "Save",
+        "description": "Label for the button to save settings"
+    },
+
+    "optionsMessageSaved": {
+        "message": "Settings saved",
+        "description": "Message to be shown after settings are successfully saved"
     }
 }

--- a/options.html
+++ b/options.html
@@ -1,48 +1,48 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>To Google Translate - Options page</title>
+  <title>__MSG_optionsPageTitle__</title>
   <meta charset="utf-8">
   <link rel="stylesheet" type="text/css" href="options.css">
 </head>
 <body>
-  <p class="title">Settings</p>
+  <p class="title">__MSG_optionsTitle__</p>
   <form>
     <table>
       <tr>
         <td class="col1 no-border help" colspan=3>
-	<span class="icon">Set the From field to 'auto' to use when encountering multiple languages.</span>
+	<span class="icon">__MSG_optionsNoteForEncounteringMultipleLanguage__</span>
         </td>
       </tr>
       <tr>
         <td class="col1">
-          Translate Text
+          __MSG_optionsTTCaption__
         </td>
         <td class="col2">
-          From <input type="text" id="pageLang" maxlength="5" size="4" required /> 
+          __MSG_optionsPageLang__ <input type="text" id="pageLang" maxlength="5" size="4" required /> 
         </td>
         <td class="col3">
-          To <input type="text" id="userLang"  maxlength="5" size="4" required /> 
+          __MSG_optionsUserLang__ <input type="text" id="userLang"  maxlength="5" size="4" required /> 
         </td>
         <td>
-          <input type="checkbox" name="enableTT" id="enableTT"> Enable
+          <input type="checkbox" name="enableTT" id="enableTT"> __MSG_optionsEnableTT__
         </td>
       </tr>
       <tr>
         <td class="col1">
-          Text To Speech
+          __MSG_optionsTTSCaption__
         </td>
         <td class="col2">
           <input type="text" id="ttsLang"  maxlength="5" size="4" required/>
         </td>
         <td class="col3"></td>
         <td>
-          <input type="checkbox" name="enableTTS" id="enableTTS"> Enable
+          <input type="checkbox" name="enableTTS" id="enableTTS"> __MSG_optionsEnableTTS__
         </td>
       </tr>
       <tr>
         <td class="col1 no-border">
-          <button type="submit" class="button">Save</button>
+          <button type="submit" class="button">__MSG_optionsSubmit__</button>
         </td>
         <td class="col2 no-border"></td>
         <td class="col3 no-border"></td>

--- a/options.html
+++ b/options.html
@@ -50,6 +50,7 @@
     </table>
   </form>
   <div id="message"></div>
+  <script src="l10n.js"></script>
   <script src="options.js"></script>
 </body>
 </html>

--- a/options.js
+++ b/options.js
@@ -31,7 +31,7 @@ function saveOptions(e) {
             chrome.i18n.getMessage('contextMenuTitleTranslate', [pageLang.value, userLang.value]));
         updateContextMenuTitle('tts', 
             chrome.i18n.getMessage('contextMenuTitleTextToSpeech', ttsLang.value));
-        showMessage('Settings saved');
+        showMessage(chrome.i18n.getMessage('contextMenuTitleTextToSpeech'));
         
         if (enableTT.checked == false) {
             removeContextMenu('translate');


### PR DESCRIPTION
Currently messages in `options.html` are hardcoded and impossible to be translated. My library https://github.com/piroor/webextensions-lib-l10n helps to fill placeholders in a HTML like `<p>__MSG_XXXX__</p>` with localized text defined in `messages.json`.

Because the external library is added as a submodule and only the JS file should be included to the package, now we need to extract `l10n.js` from the submodule directory. Thus, after this change, you need to run `make build` (or `make`) instead of `web-ext build` to create the package.

How about this? If this PR is granted, I'll update my another PR #20.