### PR TITLE
Make labels around form elements clickable

### DIFF
--- a/options.html
+++ b/options.html
@@ -19,13 +19,13 @@
           __MSG_optionsTTCaption__
         </td>
         <td class="col2">
-          __MSG_optionsPageLang__ <input type="text" id="pageLang" maxlength="5" size="4" required /> 
+          <label>__MSG_optionsPageLang__ <input type="text" id="pageLang" maxlength="5" size="4" required /></label>
         </td>
         <td class="col3">
-          __MSG_optionsUserLang__ <input type="text" id="userLang"  maxlength="5" size="4" required /> 
+          <label>__MSG_optionsUserLang__ <input type="text" id="userLang"  maxlength="5" size="4" required /></label>
         </td>
         <td>
-          <input type="checkbox" name="enableTT" id="enableTT"> __MSG_optionsEnableTT__
+          <label><input type="checkbox" name="enableTT" id="enableTT"> __MSG_optionsEnableTT__</label>
         </td>
       </tr>
       <tr>
@@ -37,7 +37,7 @@
         </td>
         <td class="col3"></td>
         <td>
-          <input type="checkbox" name="enableTTS" id="enableTTS"> __MSG_optionsEnableTTS__
+          <label><input type="checkbox" name="enableTTS" id="enableTTS"> __MSG_optionsEnableTTS__</label>
         </td>
       </tr>
       <tr>


### PR DESCRIPTION
Currently I need to click exact position of form elements: input fields and checkboxes. This is hard for me when I use a poor pointing device like a trackpad. Surrounding label text and related form element by a `<label>` element makes label text clickable to control the form element, this introduces better accessibility.