### PR TITLE
Added Translate Page & Link, Dropdown for languages in options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## To Google Translate
 ### Introduction
  
-This extension creates a context menu item in the browser, when you click on a menu item, the previously selected text is sent to Google Translate. You can also setup default language in the option page.
+This extension creates a context menu item in the browser, when you click on a menu item, the current page url or the previously selected text is sent to Google Translate. You can also setup default language in the option page.
 
 ### How to use
 #### Changing the default language

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## To Google Translate
 ### Introduction
  
-This extension creates a context menu item in the browser, when you click on a menu item, the current page url or the previously selected text is sent to Google Translate. You can also setup default language in the option page.
+This extension creates a context menu item in the browser, when you click on a menu item, the current page url, link or the previously selected text is sent to Google Translate. You can also setup default language in the option page.
 
 ### How to use
 #### Changing the default language

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -35,6 +35,21 @@
         }
     },
 
+    "contextMenuTitleTranslatePage": {
+        "message": "Translate this page ($PAGE_LANG$/$USER_LANG$)",
+        "description": "The contextMenus title.",
+        "placeholders": {
+            "page_lang": {
+                "content": "$1",
+                "example": "en"
+            },
+            "user_lang": {
+                "content": "$2",
+                "example": "es"
+            }
+        }
+    },
+
     "optionsPageTitle": {
         "message": "To Google Translate - Options page",
         "description": "Title of the options page itself."
@@ -73,6 +88,23 @@
     "optionsEnableTTS": {
         "message": "Enable",
         "description": "Label for the checkbox to show \"Listen\" menu item"
+    },
+
+    "optionsTPCaption": {
+        "message": "Translate Page",
+        "description": "Caption for text translation"
+    },
+    "optionsTPPageLang": {
+        "message": "From",
+        "description": "Preceding label for the page language"
+    },
+    "optionsTPUserLang": {
+        "message": "To",
+        "description": "Preceding label for the translated language"
+    },
+    "optionsEnableTP": {
+        "message": "Enable",
+        "description": "Label for the checkbox to show \"Translate\" menu item"
     },
 
     "optionsSubmit": {

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -50,6 +50,21 @@
         }
     },
 
+    "contextMenuTitleTranslatePageLink": {
+        "message": "Translate link ($PAGE_LANG$/$USER_LANG$)",
+        "description": "The contextMenus title.",
+        "placeholders": {
+            "page_lang": {
+                "content": "$1",
+                "example": "en"
+            },
+            "user_lang": {
+                "content": "$2",
+                "example": "es"
+            }
+        }
+    },
+
     "optionsPageTitle": {
         "message": "To Google Translate - Options page",
         "description": "Title of the options page itself."

--- a/manifest.json
+++ b/manifest.json
@@ -27,7 +27,7 @@
         "storage"
     ],
 
-    "web_accessible_resources": ["icons/help.png"],
+    "web_accessible_resources": ["icons/help.png", "supported_languages.json"],
 
     "applications": {
         "gecko": {

--- a/options.css
+++ b/options.css
@@ -60,6 +60,10 @@ input {
     text-align: center;
 }
 
+.select-lang{
+    width: 12em;
+}
+
 .button {
     border-style: hidden;
     background-color: rgb(76, 175, 80);

--- a/options.html
+++ b/options.html
@@ -41,6 +41,20 @@
         </td>
       </tr>
       <tr>
+        <td class="col1">
+          __MSG_optionsTPCaption__
+        </td>
+        <td class="col2">
+          <label>__MSG_optionsTPPageLang__ <input type="text" id="TPpageLang" maxlength="12" size="12" required /></label>
+        </td>
+        <td class="col3">
+          <label>__MSG_optionsTPUserLang__ <input type="text" id="TPuserLang"  maxlength="12" size="12" required /></label>
+        </td>
+        <td>
+          <label><input type="checkbox" name="enableTP" id="enableTP"> __MSG_optionsEnableTP__</label>
+        </td>
+      </tr>
+      <tr>
         <td class="col1 no-border">
           <button type="submit" class="button">__MSG_optionsSubmit__</button>
         </td>

--- a/options.html
+++ b/options.html
@@ -19,10 +19,10 @@
           __MSG_optionsTTCaption__
         </td>
         <td class="col2">
-          <label>__MSG_optionsPageLang__ <input type="text" id="pageLang" maxlength="12" size="12" required /></label>
+          <label>__MSG_optionsPageLang__ <select class="select-lang" name="pageLang" id="pageLang" required></select></label>
         </td>
         <td class="col3">
-          <label>__MSG_optionsUserLang__ <input type="text" id="userLang"  maxlength="12" size="12" required /></label>
+          <label>__MSG_optionsUserLang__ <select class="select-lang" name="userLang" id="userLang" required></select></label>
         </td>
         <td>
           <label><input type="checkbox" name="enableTT" id="enableTT"> __MSG_optionsEnableTT__</label>
@@ -33,7 +33,7 @@
           __MSG_optionsTTSCaption__
         </td>
         <td class="col2">
-          <input type="text" id="ttsLang"  maxlength="12" size="12" required/>
+          <select class="select-lang" name="ttsLang" id="ttsLang" required></select>
         </td>
         <td class="col3"></td>
         <td>
@@ -45,10 +45,10 @@
           __MSG_optionsTPCaption__
         </td>
         <td class="col2">
-          <label>__MSG_optionsTPPageLang__ <input type="text" id="TPpageLang" maxlength="12" size="12" required /></label>
+          <label>__MSG_optionsTPPageLang__ <select class="select-lang" name="TPpageLang" id="TPpageLang" required></select></label>
         </td>
         <td class="col3">
-          <label>__MSG_optionsTPUserLang__ <input type="text" id="TPuserLang"  maxlength="12" size="12" required /></label>
+          <label>__MSG_optionsTPUserLang__ <select class="select-lang" name="TPuserLang" id="TPuserLang" required></select></label>
         </td>
         <td>
           <label><input type="checkbox" name="enableTP" id="enableTP"> __MSG_optionsEnableTP__</label>

--- a/options.js
+++ b/options.js
@@ -40,6 +40,8 @@ function saveOptions(e) {
             chrome.i18n.getMessage('contextMenuTitleTextToSpeech', ttsLang.value));
         updateContextMenuTitle('translatePage',
             chrome.i18n.getMessage('contextMenuTitleTranslatePage', [TPpageLang.value, TPuserLang.value]));
+        updateContextMenuTitle('translatePageLink',
+            chrome.i18n.getMessage('contextMenuTitleTranslatePageLink', [TPpageLang.value, TPuserLang.value]));
         showMessage(chrome.i18n.getMessage('optionsMessageSaved'));
 
         if (enableTT.checked == false) {
@@ -69,6 +71,12 @@ function saveOptions(e) {
                 id: 'translatePage',
                 title: chrome.i18n.getMessage('contextMenuTitleTranslatePage', [TPpageLang.value, TPuserLang.value]),
                 contexts: ['all']
+            });
+
+            chrome.contextMenus.create({
+                id: 'translatePageLink',
+                title: chrome.i18n.getMessage('contextMenuTitleTranslatePageLink', [TPpageLang.value, TPuserLang.value]),
+                contexts: ['link']
             });
         }
         

--- a/options.js
+++ b/options.js
@@ -13,8 +13,11 @@ var storage = chrome.storage.local;
 var pageLang = document.querySelector('#pageLang');
 var userLang = document.querySelector('#userLang');
 var ttsLang = document.querySelector('#ttsLang');
+var TPpageLang = document.querySelector('#TPpageLang');
+var TPuserLang = document.querySelector('#TPuserLang');
 var enableTT = document.querySelector('#enableTT');
 var enableTTS = document.querySelector('#enableTTS');
+var enableTP = document.querySelector('#enableTP');
 
 function saveOptions(e) {
     e.preventDefault();
@@ -22,15 +25,21 @@ function saveOptions(e) {
         'pageLang': pageLang.value,
         'userLang': userLang.value,
         'ttsLang': ttsLang.value,
+        'TPpageLang': TPpageLang.value,
+        'TPuserLang': TPuserLang.value,
         'enableTT': enableTT.checked,
         'enableTTS': enableTTS.checked,
+        'enableTP': enableTP.checked,
         'translateURL': `https://${gtDomain}/?sl=${pageLang.value}&tl=${userLang.value}&text=`,
-        'ttsURL': `https://${gtDomain}/translate_tts?ie=UTF-8&total=1&idx=0&client=tw-ob&tl=${ttsLang.value}&q=`
+        'ttsURL': `https://${gtDomain}/translate_tts?ie=UTF-8&total=1&idx=0&client=tw-ob&tl=${ttsLang.value}&q=`,
+        'translatePageURL': `https://${gtDomain}/translate?sl=${TPpageLang.value}&tl=${TPuserLang.value}&u=`
     }, function () {
         updateContextMenuTitle('translate', 
             chrome.i18n.getMessage('contextMenuTitleTranslate', [pageLang.value, userLang.value]));
         updateContextMenuTitle('tts', 
             chrome.i18n.getMessage('contextMenuTitleTextToSpeech', ttsLang.value));
+        updateContextMenuTitle('translatePage',
+            chrome.i18n.getMessage('contextMenuTitleTranslatePage', [TPpageLang.value, TPuserLang.value]));
         showMessage(chrome.i18n.getMessage('optionsMessageSaved'));
 
         if (enableTT.checked == false) {
@@ -52,6 +61,16 @@ function saveOptions(e) {
                 contexts: ['selection']
             });
         }
+
+        if (enableTP.checked == false) {
+            removeContextMenu('translatePage');
+        } else {
+            chrome.contextMenus.create({
+                id: 'translatePage',
+                title: chrome.i18n.getMessage('contextMenuTitleTranslatePage', [TPpageLang.value, TPuserLang.value]),
+                contexts: ['all']
+            });
+        }
         
     });
 }
@@ -61,15 +80,21 @@ function loadOptions() {
         'pageLang': 'auto',
         'userLang': 'es',
         'ttsLang': 'en',
+        'TPpageLang': 'auto',
+        'TPuserLang': 'es',
         'enableTT': true,
         'enableTTS': true,
+        'enableTP': true,
         'gtDomain': getGoogleTranslatorDomain()
     }, function (items) {
         pageLang.value = items.pageLang;
         userLang.value = items.userLang;
         ttsLang.value = items.ttsLang;
+        TPpageLang.value = items.TPpageLang;
+        TPuserLang.value = items.TPuserLang;
         enableTT.checked = items.enableTT;
         enableTTS.checked = items.enableTTS;
+        enableTP.checked = items.enableTP;
         gtDomain = items.gtDomain;
     });
 }

--- a/options.js
+++ b/options.js
@@ -112,8 +112,8 @@ function loadOptions() {
             ttsLang.add(autoOption.cloneNode(true));
 
             for(let option of textOptions){
-                pageLang.add(option);
-                userLang.add(option);
+                pageLang.add(option.cloneNode(true));
+                userLang.add(option.cloneNode(true));
 
                 TPpageLang.add(option.cloneNode(true));
                 TPuserLang.add(option.cloneNode(true));

--- a/options.js
+++ b/options.js
@@ -66,6 +66,7 @@ function saveOptions(e) {
 
         if (enableTP.checked == false) {
             removeContextMenu('translatePage');
+            removeContextMenu('translatePageLink');
         } else {
             chrome.contextMenus.create({
                 id: 'translatePage',
@@ -84,26 +85,62 @@ function saveOptions(e) {
 }
 
 function loadOptions() {
-    storage.get({
-        'pageLang': 'auto',
-        'userLang': 'es',
-        'ttsLang': 'en',
-        'TPpageLang': 'auto',
-        'TPuserLang': 'es',
-        'enableTT': true,
-        'enableTTS': true,
-        'enableTP': true,
-        'gtDomain': getGoogleTranslatorDomain()
-    }, function (items) {
-        pageLang.value = items.pageLang;
-        userLang.value = items.userLang;
-        ttsLang.value = items.ttsLang;
-        TPpageLang.value = items.TPpageLang;
-        TPuserLang.value = items.TPuserLang;
-        enableTT.checked = items.enableTT;
-        enableTTS.checked = items.enableTTS;
-        enableTP.checked = items.enableTP;
-        gtDomain = items.gtDomain;
+    fetch(chrome.runtime.getURL('supported_languages.json'))
+        .then(response => response.json())
+        .then(languages => {
+
+            let textOptions = [];
+            function createOption(text,value) {
+                let option = document.createElement("option");
+                option.text = text;
+                option.value = value;
+                return option;
+            }
+
+            for(let lang of languages.text){
+                textOptions.push(createOption(lang.language, lang.code));
+            }
+
+            for(let lang of languages.tts){
+                ttsLang.add(createOption(lang.language, lang.code));
+            }
+
+            let autoOption = createOption("Auto", "auto")
+
+            pageLang.add(autoOption.cloneNode(true));
+            TPpageLang.add(autoOption.cloneNode(true));
+            ttsLang.add(autoOption.cloneNode(true));
+
+            for(let option of textOptions){
+                pageLang.add(option);
+                userLang.add(option);
+
+                TPpageLang.add(option.cloneNode(true));
+                TPuserLang.add(option.cloneNode(true));
+            }
+
+            storage.get({
+                'pageLang': 'auto',
+                'userLang': 'es',
+                'ttsLang': 'en-US',
+                'TPpageLang': 'auto',
+                'TPuserLang': 'es',
+                'enableTT': true,
+                'enableTTS': true,
+                'enableTP': true,
+                'gtDomain': getGoogleTranslatorDomain()
+            }, function (items) {
+                pageLang.value = items.pageLang;
+                userLang.value = items.userLang;
+                ttsLang.value = items.ttsLang;
+                TPpageLang.value = items.TPpageLang;
+                TPuserLang.value = items.TPuserLang;
+                enableTT.checked = items.enableTT;
+                enableTTS.checked = items.enableTTS;
+                enableTP.checked = items.enableTP;
+                gtDomain = items.gtDomain;
+            });
+
     });
 }
 

--- a/supported_languages.json
+++ b/supported_languages.json
@@ -1,0 +1,902 @@
+{
+  "text": [
+    {
+      "language": "Afrikaans",
+      "code": "af"
+    },
+    {
+      "language": "Albanian",
+      "code": "sq"
+    },
+    {
+      "language": "Amharic",
+      "code": "am"
+    },
+    {
+      "language": "Arabic",
+      "code": "ar"
+    },
+    {
+      "language": "Armenian",
+      "code": "hy"
+    },
+    {
+      "language": "Azerbaijani",
+      "code": "az"
+    },
+    {
+      "language": "Basque",
+      "code": "eu"
+    },
+    {
+      "language": "Belarusian",
+      "code": "be"
+    },
+    {
+      "language": "Bengali",
+      "code": "bn"
+    },
+    {
+      "language": "Bosnian",
+      "code": "bs"
+    },
+    {
+      "language": "Bulgarian",
+      "code": "bg"
+    },
+    {
+      "language": "Catalan",
+      "code": "ca"
+    },
+    {
+      "language": "Cebuano",
+      "code": "ceb"
+    },
+    {
+      "language": "Chinese (Simplified)",
+      "code": "zh-CN"
+    },
+    {
+      "language": "Chinese (Traditional)",
+      "code": "zh-TW"
+    },
+    {
+      "language": "Corsican",
+      "code": "co"
+    },
+    {
+      "language": "Croatian",
+      "code": "hr"
+    },
+    {
+      "language": "Czech",
+      "code": "cs"
+    },
+    {
+      "language": "Danish",
+      "code": "da"
+    },
+    {
+      "language": "Dutch",
+      "code": "nl"
+    },
+    {
+      "language": "English",
+      "code": "en"
+    },
+    {
+      "language": "Esperanto",
+      "code": "eo"
+    },
+    {
+      "language": "Estonian",
+      "code": "et"
+    },
+    {
+      "language": "Finnish",
+      "code": "fi"
+    },
+    {
+      "language": "French",
+      "code": "fr"
+    },
+    {
+      "language": "Frisian",
+      "code": "fy"
+    },
+    {
+      "language": "Galician",
+      "code": "gl"
+    },
+    {
+      "language": "Georgian",
+      "code": "ka"
+    },
+    {
+      "language": "German",
+      "code": "de"
+    },
+    {
+      "language": "Greek",
+      "code": "el"
+    },
+    {
+      "language": "Gujarati",
+      "code": "gu"
+    },
+    {
+      "language": "Haitian Creole",
+      "code": "ht"
+    },
+    {
+      "language": "Hausa",
+      "code": "ha"
+    },
+    {
+      "language": "Hawaiian",
+      "code": "haw"
+    },
+    {
+      "language": "Hebrew",
+      "code": "he**"
+    },
+    {
+      "language": "Hindi",
+      "code": "hi"
+    },
+    {
+      "language": "Hmong",
+      "code": "hmn"
+    },
+    {
+      "language": "Hungarian",
+      "code": "hu"
+    },
+    {
+      "language": "Icelandic",
+      "code": "is"
+    },
+    {
+      "language": "Igbo",
+      "code": "ig"
+    },
+    {
+      "language": "Indonesian",
+      "code": "id"
+    },
+    {
+      "language": "Irish",
+      "code": "ga"
+    },
+    {
+      "language": "Italian",
+      "code": "it"
+    },
+    {
+      "language": "Japanese",
+      "code": "ja"
+    },
+    {
+      "language": "Javanese",
+      "code": "jw"
+    },
+    {
+      "language": "Kannada",
+      "code": "kn"
+    },
+    {
+      "language": "Kazakh",
+      "code": "kk"
+    },
+    {
+      "language": "Khmer",
+      "code": "km"
+    },
+    {
+      "language": "Korean",
+      "code": "ko"
+    },
+    {
+      "language": "Kurdish",
+      "code": "ku"
+    },
+    {
+      "language": "Kyrgyz",
+      "code": "ky"
+    },
+    {
+      "language": "Lao",
+      "code": "lo"
+    },
+    {
+      "language": "Latin",
+      "code": "la"
+    },
+    {
+      "language": "Latvian",
+      "code": "lv"
+    },
+    {
+      "language": "Lithuanian",
+      "code": "lt"
+    },
+    {
+      "language": "Luxembourgish",
+      "code": "lb"
+    },
+    {
+      "language": "Macedonian",
+      "code": "mk"
+    },
+    {
+      "language": "Malagasy",
+      "code": "mg"
+    },
+    {
+      "language": "Malay",
+      "code": "ms"
+    },
+    {
+      "language": "Malayalam",
+      "code": "ml"
+    },
+    {
+      "language": "Maltese",
+      "code": "mt"
+    },
+    {
+      "language": "Maori",
+      "code": "mi"
+    },
+    {
+      "language": "Marathi",
+      "code": "mr"
+    },
+    {
+      "language": "Mongolian",
+      "code": "mn"
+    },
+    {
+      "language": "Myanmar (Burmese)",
+      "code": "my"
+    },
+    {
+      "language": "Nepali",
+      "code": "ne"
+    },
+    {
+      "language": "Norwegian",
+      "code": "no"
+    },
+    {
+      "language": "Nyanja (Chichewa)",
+      "code": "ny"
+    },
+    {
+      "language": "Pashto",
+      "code": "ps"
+    },
+    {
+      "language": "Persian",
+      "code": "fa"
+    },
+    {
+      "language": "Polish",
+      "code": "pl"
+    },
+    {
+      "language": "Portuguese (Portugal, Brazil)",
+      "code": "pt"
+    },
+    {
+      "language": "Punjabi",
+      "code": "pa"
+    },
+    {
+      "language": "Romanian",
+      "code": "ro"
+    },
+    {
+      "language": "Russian",
+      "code": "ru"
+    },
+    {
+      "language": "Samoan",
+      "code": "sm"
+    },
+    {
+      "language": "Scots Gaelic",
+      "code": "gd"
+    },
+    {
+      "language": "Serbian",
+      "code": "sr"
+    },
+    {
+      "language": "Sesotho",
+      "code": "st"
+    },
+    {
+      "language": "Shona",
+      "code": "sn"
+    },
+    {
+      "language": "Sindhi",
+      "code": "sd"
+    },
+    {
+      "language": "Sinhala (Sinhalese)",
+      "code": "si"
+    },
+    {
+      "language": "Slovak",
+      "code": "sk"
+    },
+    {
+      "language": "Slovenian",
+      "code": "sl"
+    },
+    {
+      "language": "Somali",
+      "code": "so"
+    },
+    {
+      "language": "Spanish",
+      "code": "es"
+    },
+    {
+      "language": "Sundanese",
+      "code": "su"
+    },
+    {
+      "language": "Swahili",
+      "code": "sw"
+    },
+    {
+      "language": "Swedish",
+      "code": "sv"
+    },
+    {
+      "language": "Tagalog (Filipino)",
+      "code": "tl"
+    },
+    {
+      "language": "Tajik",
+      "code": "tg"
+    },
+    {
+      "language": "Tamil",
+      "code": "ta"
+    },
+    {
+      "language": "Telugu",
+      "code": "te"
+    },
+    {
+      "language": "Thai",
+      "code": "th"
+    },
+    {
+      "language": "Turkish",
+      "code": "tr"
+    },
+    {
+      "language": "Ukrainian",
+      "code": "uk"
+    },
+    {
+      "language": "Urdu",
+      "code": "ur"
+    },
+    {
+      "language": "Uzbek",
+      "code": "uz"
+    },
+    {
+      "language": "Vietnamese",
+      "code": "vi"
+    },
+    {
+      "language": "Welsh",
+      "code": "cy"
+    },
+    {
+      "language": "Xhosa",
+      "code": "xh"
+    },
+    {
+      "language": "Yiddish",
+      "code": "yi"
+    },
+    {
+      "language": "Yoruba",
+      "code": "yo"
+    },
+    {
+      "language": "Zulu",
+      "code": "zu"
+    }
+  ],
+  "tts": [
+    {
+      "language": "Afrikaans (South Africa)",
+      "code": "af-ZA"
+    },
+    {
+      "language": "Amharic (Ethiopia)",
+      "code": "am-ET"
+    },
+    {
+      "language": "Armenian (Armenia)",
+      "code": "hy-AM"
+    },
+    {
+      "language": "Azerbaijani (Azerbaijan)",
+      "code": "az-AZ"
+    },
+    {
+      "language": "Indonesian (Indonesia)",
+      "code": "id-ID"
+    },
+    {
+      "language": "Malay (Malaysia)",
+      "code": "ms-MY"
+    },
+    {
+      "language": "Bengali (Bangladesh)",
+      "code": "bn-BD"
+    },
+    {
+      "language": "Bengali (India)",
+      "code": "bn-IN"
+    },
+    {
+      "language": "Catalan (Spain)",
+      "code": "ca-ES"
+    },
+    {
+      "language": "Czech (Czech Republic)",
+      "code": "cs-CZ"
+    },
+    {
+      "language": "Danish (Denmark)",
+      "code": "da-DK"
+    },
+    {
+      "language": "German (Germany)",
+      "code": "de-DE"
+    },
+    {
+      "language": "English (Australia)",
+      "code": "en-AU"
+    },
+    {
+      "language": "English (Canada)",
+      "code": "en-CA"
+    },
+    {
+      "language": "English (Ghana)",
+      "code": "en-GH"
+    },
+    {
+      "language": "English (United Kingdom)",
+      "code": "en-GB"
+    },
+    {
+      "language": "English (India)",
+      "code": "en-IN"
+    },
+    {
+      "language": "English (Ireland)",
+      "code": "en-IE"
+    },
+    {
+      "language": "English (Kenya)",
+      "code": "en-KE"
+    },
+    {
+      "language": "English (New Zealand)",
+      "code": "en-NZ"
+    },
+    {
+      "language": "English (Nigeria)",
+      "code": "en-NG"
+    },
+    {
+      "language": "English (Philippines)",
+      "code": "en-PH"
+    },
+    {
+      "language": "English (Singapore)",
+      "code": "en-SG"
+    },
+    {
+      "language": "English (South Africa)",
+      "code": "en-ZA"
+    },
+    {
+      "language": "English (Tanzania)",
+      "code": "en-TZ"
+    },
+    {
+      "language": "English (United States)",
+      "code": "en-US"
+    },
+    {
+      "language": "Spanish (Argentina)",
+      "code": "es-AR"
+    },
+    {
+      "language": "Spanish (Bolivia)",
+      "code": "es-BO"
+    },
+    {
+      "language": "Spanish (Chile)",
+      "code": "es-CL"
+    },
+    {
+      "language": "Spanish (Colombia)",
+      "code": "es-CO"
+    },
+    {
+      "language": "Spanish (Costa Rica)",
+      "code": "es-CR"
+    },
+    {
+      "language": "Spanish (Ecuador)",
+      "code": "es-EC"
+    },
+    {
+      "language": "Spanish (El Salvador)",
+      "code": "es-SV"
+    },
+    {
+      "language": "Spanish (Spain)",
+      "code": "es-ES"
+    },
+    {
+      "language": "Spanish (United States)",
+      "code": "es-US"
+    },
+    {
+      "language": "Spanish (Guatemala)",
+      "code": "es-GT"
+    },
+    {
+      "language": "Spanish (Honduras)",
+      "code": "es-HN"
+    },
+    {
+      "language": "Spanish (Mexico)",
+      "code": "es-MX"
+    },
+    {
+      "language": "Spanish (Nicaragua)",
+      "code": "es-NI"
+    },
+    {
+      "language": "Spanish (Panama)",
+      "code": "es-PA"
+    },
+    {
+      "language": "Spanish (Paraguay)",
+      "code": "es-PY"
+    },
+    {
+      "language": "Spanish (Peru)",
+      "code": "es-PE"
+    },
+    {
+      "language": "Spanish (Puerto Rico)",
+      "code": "es-PR"
+    },
+    {
+      "language": "Spanish (Dominican Republic)",
+      "code": "es-DO"
+    },
+    {
+      "language": "Spanish (Uruguay)",
+      "code": "es-UY"
+    },
+    {
+      "language": "Spanish (Venezuela)",
+      "code": "es-VE"
+    },
+    {
+      "language": "Basque (Spain)",
+      "code": "eu-ES"
+    },
+    {
+      "language": "Filipino (Philippines)",
+      "code": "fil-PH"
+    },
+    {
+      "language": "French (Canada)",
+      "code": "fr-CA"
+    },
+    {
+      "language": "French (France)",
+      "code": "fr-FR"
+    },
+    {
+      "language": "Galician (Spain)",
+      "code": "gl-ES"
+    },
+    {
+      "language": "Georgian (Georgia)",
+      "code": "ka-GE"
+    },
+    {
+      "language": "Gujarati (India)",
+      "code": "gu-IN"
+    },
+    {
+      "language": "Croatian (Croatia)",
+      "code": "hr-HR"
+    },
+    {
+      "language": "Zulu (South Africa)",
+      "code": "zu-ZA"
+    },
+    {
+      "language": "Icelandic (Iceland)",
+      "code": "is-IS"
+    },
+    {
+      "language": "Italian (Italy)",
+      "code": "it-IT"
+    },
+    {
+      "language": "Javanese (Indonesia)",
+      "code": "jv-ID"
+    },
+    {
+      "language": "Kannada (India)",
+      "code": "kn-IN"
+    },
+    {
+      "language": "Khmer (Cambodia)",
+      "code": "km-KH"
+    },
+    {
+      "language": "Lao (Laos)",
+      "code": "lo-LA"
+    },
+    {
+      "language": "Latvian (Latvia)",
+      "code": "lv-LV"
+    },
+    {
+      "language": "Lithuanian (Lithuania)",
+      "code": "lt-LT"
+    },
+    {
+      "language": "Hungarian (Hungary)",
+      "code": "hu-HU"
+    },
+    {
+      "language": "Malayalam (India)",
+      "code": "ml-IN"
+    },
+    {
+      "language": "Marathi (India)",
+      "code": "mr-IN"
+    },
+    {
+      "language": "Dutch (Netherlands)",
+      "code": "nl-NL"
+    },
+    {
+      "language": "Nepali (Nepal)",
+      "code": "ne-NP"
+    },
+    {
+      "language": "Norwegian Bokmål (Norway)",
+      "code": "nb-NO"
+    },
+    {
+      "language": "Polish (Poland)",
+      "code": "pl-PL"
+    },
+    {
+      "language": "Portuguese (Brazil)",
+      "code": "pt-BR"
+    },
+    {
+      "language": "Portuguese (Portugal)",
+      "code": "pt-PT"
+    },
+    {
+      "language": "Romanian (Romania)",
+      "code": "ro-RO"
+    },
+    {
+      "language": "Sinhala (Sri Lanka)",
+      "code": "si-LK"
+    },
+    {
+      "language": "Slovak (Slovakia)",
+      "code": "sk-SK"
+    },
+    {
+      "language": "Slovenian (Slovenia)",
+      "code": "sl-SI"
+    },
+    {
+      "language": "Sundanese (Indonesia)",
+      "code": "su-ID"
+    },
+    {
+      "language": "Swahili (Tanzania)",
+      "code": "sw-TZ"
+    },
+    {
+      "language": "Swahili (Kenya)",
+      "code": "sw-KE"
+    },
+    {
+      "language": "Finnish (Finland)",
+      "code": "fi-FI"
+    },
+    {
+      "language": "Swedish (Sweden)",
+      "code": "sv-SE"
+    },
+    {
+      "language": "Tamil (India)",
+      "code": "ta-IN"
+    },
+    {
+      "language": "Tamil (Singapore)",
+      "code": "ta-SG"
+    },
+    {
+      "language": "Tamil (Sri Lanka)",
+      "code": "ta-LK"
+    },
+    {
+      "language": "Tamil (Malaysia)",
+      "code": "ta-MY"
+    },
+    {
+      "language": "Telugu (India)",
+      "code": "te-IN"
+    },
+    {
+      "language": "Vietnamese (Vietnam)",
+      "code": "vi-VN"
+    },
+    {
+      "language": "Turkish (Turkey)",
+      "code": "tr-TR"
+    },
+    {
+      "language": "Urdu (Pakistan)",
+      "code": "ur-PK"
+    },
+    {
+      "language": "Urdu (India)",
+      "code": "ur-IN"
+    },
+    {
+      "language": "Greek (Greece)",
+      "code": "el-GR"
+    },
+    {
+      "language": "Bulgarian (Bulgaria)",
+      "code": "bg-BG"
+    },
+    {
+      "language": "Russian (Russia)",
+      "code": "ru-RU"
+    },
+    {
+      "language": "Serbian (Serbia)",
+      "code": "sr-RS"
+    },
+    {
+      "language": "Ukrainian (Ukraine)",
+      "code": "uk-UA"
+    },
+    {
+      "language": "Hebrew (Israel)",
+      "code": "he-IL"
+    },
+    {
+      "language": "Arabic (Israel)",
+      "code": "ar-IL"
+    },
+    {
+      "language": "Arabic (Jordan)",
+      "code": "ar-JO"
+    },
+    {
+      "language": "Arabic (United Arab Emirates)",
+      "code": "ar-AE"
+    },
+    {
+      "language": "Arabic (Bahrain)",
+      "code": "ar-BH"
+    },
+    {
+      "language": "Arabic (Algeria)",
+      "code": "ar-DZ"
+    },
+    {
+      "language": "Arabic (Saudi Arabia)",
+      "code": "ar-SA"
+    },
+    {
+      "language": "Arabic (Iraq)",
+      "code": "ar-IQ"
+    },
+    {
+      "language": "Arabic (Kuwait)",
+      "code": "ar-KW"
+    },
+    {
+      "language": "Arabic (Morocco)",
+      "code": "ar-MA"
+    },
+    {
+      "language": "Arabic (Tunisia)",
+      "code": "ar-TN"
+    },
+    {
+      "language": "Arabic (Oman)",
+      "code": "ar-OM"
+    },
+    {
+      "language": "Arabic (State of Palestine)",
+      "code": "ar-PS"
+    },
+    {
+      "language": "Arabic (Qatar)",
+      "code": "ar-QA"
+    },
+    {
+      "language": "Arabic (Lebanon)",
+      "code": "ar-LB"
+    },
+    {
+      "language": "Arabic (Egypt)",
+      "code": "ar-EG"
+    },
+    {
+      "language": "Persian (Iran)",
+      "code": "fa-IR"
+    },
+    {
+      "language": "Hindi (India)",
+      "code": "hi-IN"
+    },
+    {
+      "language": "Thai (Thailand)",
+      "code": "th-TH"
+    },
+    {
+      "language": "Korean (South Korea)",
+      "code": "ko-KR"
+    },
+    {
+      "language": "Chinese, Mandarin (Traditional, Taiwan)",
+      "code": "zh-TW"
+    },
+    {
+      "language": "Chinese, Cantonese (Traditional, Hong Kong)",
+      "code": "yue-Hant-HK"
+    },
+    {
+      "language": "Japanese (Japan)",
+      "code": "ja-JP"
+    },
+    {
+      "language": "Chinese, Mandarin (Simplified, Hong Kong)",
+      "code": "zh-HK"
+    },
+    {
+      "language": "Chinese, Mandarin (Simplified, China)",
+      "code": "zh"
+    }
+  ]
+}

--- a/translate.js
+++ b/translate.js
@@ -72,14 +72,19 @@ storage.get({
             title: chrome.i18n.getMessage('contextMenuTitleTranslatePage', [TPpageLang, TPuserLang]),
             contexts: ['all']
         });
+
+        chrome.contextMenus.create({
+            id: 'translatePageLink',
+            title: chrome.i18n.getMessage('contextMenuTitleTranslatePageLink', [TPpageLang, TPuserLang]),
+            contexts: ['link']
+        });
     }
 });
 
 // manage click context menu
 chrome.contextMenus.onClicked.addListener(function (info, tab) {
     var selectedText = info.selectionText;
-    var currentURL = info.pageUrl;
-    
+
     if (info.menuItemId == 'translate') {
         storage.get({
             'translateURL': `https://${getGoogleTranslatorDomain()}/?sl=auto&tl=es&text=`
@@ -100,7 +105,15 @@ chrome.contextMenus.onClicked.addListener(function (info, tab) {
         storage.get({
             'translatePageURL': `https://${getGoogleTranslatorDomain()}/translate?sl=auto&tl=es&u=`
         }, function (item) {
-            tabCreateWithOpenerTabId(item.translatePageURL+encodeURIComponent(currentURL), tab);
+            tabCreateWithOpenerTabId(item.translatePageURL+encodeURIComponent(info.pageUrl), tab);
+        });
+    }
+
+    if (info.menuItemId == 'translatePageLink') {
+        storage.get({
+            'translatePageURL': `https://${getGoogleTranslatorDomain()}/translate?sl=auto&tl=es&u=`
+        }, function (item) {
+            tabCreateWithOpenerTabId(item.translatePageURL+encodeURIComponent(info.linkUrl), tab);
         });
     }
 });

--- a/translate.js
+++ b/translate.js
@@ -118,6 +118,12 @@ chrome.contextMenus.onClicked.addListener(function (info, tab) {
     }
 });
 
+chrome.runtime.onInstalled.addListener(function(info){
+    if(info.reason === "install"){
+        chrome.runtime.openOptionsPage();
+    }
+});
+
 function getGoogleTranslatorDomain() {
     var offset = new Date().getTimezoneOffset();
     // Domain for China

--- a/translate.js
+++ b/translate.js
@@ -33,7 +33,7 @@ var storage = chrome.storage.local;
 storage.get({
     'pageLang': 'auto',
     'userLang': 'es',
-    'ttsLang': 'en',
+    'ttsLang': 'en-US',
     'TPpageLang': 'auto',
     'TPuserLang': 'es',
     'enableTT': true,

--- a/translate.js
+++ b/translate.js
@@ -34,15 +34,21 @@ storage.get({
     'pageLang': 'auto',
     'userLang': 'es',
     'ttsLang': 'en',
+    'TPpageLang': 'auto',
+    'TPuserLang': 'es',
     'enableTT': true,
-    'enableTTS': true
+    'enableTTS': true,
+    'enableTP': true
 }, function (items) {
     var pageLang = items.pageLang,
         userLang = items.userLang,
-        ttsLang = items.ttsLang;
-        enableTT = items.enableTT;
-        enableTTS = items.enableTTS;
-    
+        ttsLang = items.ttsLang,
+        TPpageLang = items.TPpageLang,
+        TPuserLang = items.TPuserLang,
+        enableTT = items.enableTT,
+        enableTTS = items.enableTTS,
+        enableTP = items.enableTP;
+
     // create Translate context menu
     if (enableTT == true) {
         chrome.contextMenus.create({
@@ -59,11 +65,20 @@ storage.get({
             contexts: ['selection']
         });
     }
+    // create Translate Page context menu
+    if (enableTP == true) {
+        chrome.contextMenus.create({
+            id: 'translatePage',
+            title: chrome.i18n.getMessage('contextMenuTitleTranslatePage', [TPpageLang, TPuserLang]),
+            contexts: ['all']
+        });
+    }
 });
 
-// manage clic context menu
+// manage click context menu
 chrome.contextMenus.onClicked.addListener(function (info, tab) {
     var selectedText = info.selectionText;
+    var currentURL = info.pageUrl;
     
     if (info.menuItemId == 'translate') {
         storage.get({
@@ -78,6 +93,14 @@ chrome.contextMenus.onClicked.addListener(function (info, tab) {
             'ttsURL': `https://${getGoogleTranslatorDomain()}/translate_tts?ie=UTF-8&total=1&idx=0&client=tw-ob&tl=en&q=`
         }, function (item) {
             tabCreateWithOpenerTabId(item.ttsURL+encodeURIComponent(selectedText)+'&textlen='+selectedText.length, tab);
+        });
+    }
+
+    if (info.menuItemId == 'translatePage') {
+        storage.get({
+            'translatePageURL': `https://${getGoogleTranslatorDomain()}/translate?sl=auto&tl=es&u=`
+        }, function (item) {
+            tabCreateWithOpenerTabId(item.translatePageURL+encodeURIComponent(currentURL), tab);
         });
     }
 });

--- a/translate.js
+++ b/translate.js
@@ -119,21 +119,14 @@ function getGoogleTranslatorDomain() {
 // Create a tab with openerTabId if version of Firefox is above 57
 // https://github.com/itsecurityco/to-google-translate/pull/19
 function tabCreateWithOpenerTabId(uri, tab) {
-    function gotBrowserInfo(info) {
-        FirefoxVersion = Math.round(parseInt(info.version));
-        if (FirefoxVersion < 57) {
-            // openerTabId not supported
-            chrome.tabs.create({
-                url: uri
-            });
-        } else {
+    browser.runtime.getBrowserInfo().then(info => {
+        let newTabConfig = {
+            url: uri
+        };
+        if (Math.round(parseInt(info.version)) > 56) {
             // openerTabId supported
-            chrome.tabs.create({
-                url: uri,
-                openerTabId: tab.id
-            });
+            newTabConfig.openerTabId = tab.id;
         }
-    }
-    var gettingInfo = browser.runtime.getBrowserInfo();
-    gettingInfo.then(gotBrowserInfo);
+        chrome.tabs.create(newTabConfig);
+    });
 }


### PR DESCRIPTION

Added new context menu item to translate the whole page or link
Added supported languages & dropdown for languages in options 

other changes: 
- after extension installation, options page open to set the language settings
- refactored tabCreateWithOpenerTabId function

![options](https://user-images.githubusercontent.com/6598377/54483044-eb620380-4855-11e9-8ee1-b34c5dbc7883.png)

![translate page and link](https://user-images.githubusercontent.com/6598377/54481666-4557ce80-4840-11e9-9d25-4582b2263a7b.png)
![translate page](https://user-images.githubusercontent.com/6598377/54481667-45f06500-4840-11e9-9582-631fbf5ae73e.png)
![redirected](https://user-images.githubusercontent.com/6598377/54481668-45f06500-4840-11e9-9898-f3845851d4f7.png)
