### PR TITLE
Fix duplicate options

### DIFF
--- a/options.js
+++ b/options.js
@@ -44,7 +44,7 @@ function saveOptions(e) {
         'enableTP': enableTP.checked,
         'selectedDomain': selectedDomain,
         'gtDomain': domains[selectedDomain],
-        'translateURL': `https://${gtDomain}/?sl=${pageLang.value}&tl=${userLang.value}&text=`,
+        'translateURL': `https://${gtDomain}/#view=home&op=translate&sl=${pageLang.value}&tl=${userLang.value}&text=`,
         'ttsURL': `https://${gtDomain}/translate_tts?ie=UTF-8&total=1&idx=0&client=tw-ob&tl=${ttsLang.value}&q=`,
         'translatePageURL': `https://${gtDomain}/translate?sl=${TPpageLang.value}&tl=${TPuserLang.value}&u=`
     }, function () {

--- a/translate.js
+++ b/translate.js
@@ -94,7 +94,7 @@ chrome.contextMenus.onClicked.addListener(function (info, tab) {
 
     if (info.menuItemId == 'translate') {
         storage.get({
-            'translateURL': `https://${gtDomain}/?sl=auto&tl=es&text=`
+            'translateURL': `https://${gtDomain}/#view=home&op=translate&sl=auto&tl=es&text=`
         }, function (item) {
             tabCreateWithOpenerTabId(item.translateURL+encodeURIComponent(selectedText), tab);
         });


### PR DESCRIPTION
**NOTE: This fixed is tiny. No need to hurry.**

Fixed an issue where duplicate options were passed.

#   Before
```
https://translate.google.com/?sl=auto&tl=ja&text=Lorem%20ipsum#view=home&op=translate&sl=auto&tl=ja&text=Lorem%20ipsum
```

#   After
```
https://translate.google.com/#view=home&op=translate&sl=auto&tl=es&text=Lorem%20ipsum
```

