### PR TITLE
Translate localized messages in modals

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -37,7 +37,7 @@
                 "http://*/*",
                 "https://*/*"
             ],
-            "js": ["src/config.js", "src/content/modal.js", "src/content/modal_iframe.js", "src/content/content.js"],
+            "js": ["src/config.js", "src/content/modal.js", "src/content/modal_iframe.js", "src/content/content.js", "src/l10n.js"],
             "run_at": "document_idle",
             "all_frames": true
         },

--- a/src/content/modal.html
+++ b/src/content/modal.html
@@ -110,4 +110,3 @@
         </div>
     </div>
 </div>
-<script src="../l10n.js"></script>

--- a/src/content/modal.js
+++ b/src/content/modal.js
@@ -80,6 +80,8 @@ class Modal {
                     }
                 };
 
+                l10n.updateSubtree(this.shadow.querySelector('.modal'));
+
                 return true;
             });
     }

--- a/src/content/modal_iframe.html
+++ b/src/content/modal_iframe.html
@@ -108,4 +108,3 @@
         </div>
     </div>
 </div>
-<script src="../l10n.js"></script>

--- a/src/content/modal_iframe.js
+++ b/src/content/modal_iframe.js
@@ -88,6 +88,8 @@ class ModalIframe {
                     this.destroy();
                 }
             };
+
+            l10n.updateSubtree(this.iframeContent.querySelector(".modal"));
         };
 
         this.iframe.src = chrome.runtime.getURL('src/content/modal_iframe.html');


### PR DESCRIPTION
Sorry, old versions of l10n.js didn't provide ability to translate text under shadow nodes. I've added a new utility method to translate text under arbitrary node and updated codes to use it. How about this?