### PR TITLE
Translate modal header

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -37,7 +37,13 @@
                 "http://*/*",
                 "https://*/*"
             ],
-            "js": ["src/config.js", "src/content/modal.js", "src/content/modal_iframe.js", "src/content/content.js"],
+            "js": [
+                "src/config.js",
+                "src/content/modal.js",
+                "src/content/modal_iframe.js",
+                "src/content/content.js",
+                "src/l10n.js"
+            ],
             "run_at": "document_idle",
             "all_frames": true
         },

--- a/src/content/modal.html
+++ b/src/content/modal.html
@@ -110,4 +110,3 @@
         </div>
     </div>
 </div>
-<script src="../l10n.js"></script>

--- a/src/content/modal.js
+++ b/src/content/modal.js
@@ -24,7 +24,7 @@ class Modal {
             .then(resp => resp.text())
             .then(html => {
 
-                this.shadow.innerHTML = html;
+                this.shadow.innerHTML = l10n.updateString(html);
 
                 if (this.fullscreen) {
                     this.shadow.querySelector(".modal").classList.add("modal-fullscreen");


### PR DESCRIPTION
Hey, it seems to me I managed to **run translation** on the **modal header**.

First of all, the js include path is invalid without `runtime.getURL()`. It's ok on the options page, but that is a different scope. Even fix this didn't solve the issue, I'm not quite sure it is possible to run JavaScript on that way.

Luckily I found the HTML source in a variable, so I simply added **l10n to manifest** file and **run translation function** on it.

I don't know what `modal_iframe` does but looks like it can have a similar issue. Cheers!