### PR TITLE
Run content script only on the parent document

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -45,7 +45,7 @@
                 "src/l10n.js"
             ],
             "run_at": "document_idle",
-            "all_frames": true
+            "all_frames": false
         },
         {
             "matches": [


### PR DESCRIPTION
This MR fixes #74 

Running the content script only on the parent document prevents modal injection into the child iframes.