### PR TITLE
Close the modal if it is already open with the same key bindings.

### DIFF
--- a/src/content/content.js
+++ b/src/content/content.js
@@ -1,18 +1,30 @@
+let tgt_model;
+
 chrome.runtime.onMessage.addListener(function (message, sender, callback) {
     if (message.url) {
-        show_modal(message.url, message.fullscreen);
+        if (tgt_model === undefined) {
+            show_modal(message.url, message.fullscreen);
+        } else {
+            close_modal();
+        }
     }
 });
 
 function show_modal(url, fullscreen = false) {
     let agentMatch = window.navigator.userAgent.match(/Firefox\/([0-9]+)\./);
     let firefoxVersion = agentMatch ? parseInt(agentMatch[1]) : 0;
-
-    let tgt_model = firefoxVersion > 63
+    
+    tgt_model = firefoxVersion > 63
         ? new Modal({url: url, fullscreen: fullscreen}, false)
         : new ModalIframe({url: url, fullscreen: fullscreen}, false);
-
+    
     tgt_model.build().then(() => {
         tgt_model.show();
     });
 }
+
+function close_modal() {
+    tgt_model.destroy();
+    tgt_model = undefined; // Leave back to initial state undefined.
+}
+


### PR DESCRIPTION
It allows to close the opened modal with the same key binding used to opened.

Tested with the 3 options (Ctrl+Shift+1, Ctrl+Shift+2 and Ctrl+Shift+3) on Firefox 76.