### PR TITLE
fix: Odia language added

### DIFF
--- a/supported_languages.json
+++ b/supported_languages.json
@@ -273,6 +273,10 @@
       "code": "ny"
     },
     {
+      "language": "Odia (Oriya)",
+      "code": "or"
+    },
+    {
       "language": "Pashto",
       "code": "ps"
     },


### PR DESCRIPTION
Odia language has been added to the supported language list, as it is already available in Google.
[Reference](https://translate.google.com/?sl=auto&tl=or&text=Hello&op=translate)