### PR TITLE
bring back modal and browser action

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -21,6 +21,16 @@
           "src/background/translate.js"
         ]
     },
+    "browser_action": {
+        "default_title": "Google Translate",
+        "default_icon": {
+            "16": "icons/logo-16.png",
+            "32": "icons/logo-32.png",
+            "48": "icons/logo-48.png",
+            "96": "icons/logo-96.png"
+        },
+        "default_popup": "src/popup/popup.html"
+    },
     "content_scripts": [
         {
             "matches": [

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -41,7 +41,7 @@
           <label>__MSG_optionsOpenModeNewTab__ <input type="radio" value="newTab" name="openMode" required></label>
         </td>
         <td class="col3">
-          <!--<label>__MSG_optionsOpenModeModal__ <input type="radio" value="modal" name="openMode" required disabled></label>-->          
+          <label>__MSG_optionsOpenModeModal__ <input type="radio" value="modal" name="openMode" required disabled></label>
         </td>
       </tr>
       <tr>


### PR DESCRIPTION
Both are working fine (at least with Firefox 93 on windows)

Default action remains "new tab"